### PR TITLE
Add some metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,12 @@ topic:
 		--topic events
 	docker-compose down
 
+list-topic:
+	docker-compose run --rm --service-ports make-topic sh ./bin/kafka-topics.sh \
+		--list \
+		--zookeeper kafka:2181
+	docker-compose down
+
 up:
 	docker-compose up --build ; docker-compose down
 

--- a/event-producer/src/main/java/com/mapr/examples/Producer.java
+++ b/event-producer/src/main/java/com/mapr/examples/Producer.java
@@ -74,14 +74,15 @@ public class Producer {
             "\"type\":\"frontend-event\"," +
             "\"timestamp\":%d," +
             "\"name\":\"%s\"," +
-            "\"host\":\"arch-vader\"," +
-            "\"service\":\"frontend-events-producer\"," +
+            "\"host\":\"the-producer\"," +
+            "\"service\":\"frontend-events/%s\"," +
             "\"state\":\"ok\"," +
             "\"tags\":[\"frontend-events\"]," +
-            "\"session_id\":\"%s\"," +
-            "\"instance_id\":\"%s\"" +
+            "\"sid\":\"%s\"," +
+            "\"iid\":\"%s\"" +
             "}",
             System.currentTimeMillis(),
+            name,
             name,
             sessionId,
             instanceId

--- a/riemann/riemann.config
+++ b/riemann/riemann.config
@@ -1,6 +1,8 @@
 ; -*- mode: clojure; -*-
 ; vim: filetype=clojure
 
+(use '[clojure.string :only (join)])
+(use '[clojure.math.numeric-tower :only (abs)])
 (logging/init {:file "/var/log/riemann/riemann.log"})
 
 (def graph (graphite {:host "grafana_graphite" :port 2003}))
@@ -18,7 +20,7 @@
 (let [index (index)]
   ; Inbound events will be passed to these streams:
   (streams
-    (default :ttl 60
+    (default :ttl 30
       ; Index all events immediately.
       index
 
@@ -30,6 +32,48 @@
                                    :group.id "test"}
                  :topics ["events"]})
 
+(defn set-host-and-ttl [incoming-event]
+  (assoc incoming-event :host (join "_" [(:host incoming-event) (:sid incoming-event) (:iid incoming-event)]) :ttl 10 :metric 42))
+
+; adds "_count" at the end of the service name
+(defn rename-count [ev]
+  (assoc ev :service (join "_" [(:service ev) "count"])))
+
+; copies the "timestamp" property to the "metric" property
+(defn timestamp-as-metric [ev]
+  (assoc ev :metric (:timestamp ev)))
+
 (streams
-  graph
-  #(info %))
+  ; calculate time difference between created/loaded events
+  (by [:sid :iid]
+    (smap timestamp-as-metric
+      (project [(service "frontend-events/main_iframe_created")
+                (service "frontend-events/main_iframe_loaded")]
+        (smap folds/difference (with :service "frontend-events/main_iframe_created_to_loaded"
+                                  graph)))))
+
+  ; count the occurrences of the distinct events
+  (tagged "frontend-events"
+    (by [:host :service]
+      (smap rename-count
+        (moving-time-window 60
+          (smap folds/count graph))))))
+
+; -----------------------------
+; event names
+; -----------------------------
+; fullscreen_iframe_loaded
+; fullscreen_iframe_created
+; fullscreen_iframe_timed_out
+; main_iframe_created
+; main_iframe_loaded
+; main_iframe_visible
+; main_iframe_timed_out
+; dr_iframe_loaded
+; dr_iframe_created
+; dr_iframe_timed_out
+
+; (streams
+;   graph
+;   #(info %))
+

--- a/riemann/riemann.config
+++ b/riemann/riemann.config
@@ -2,7 +2,6 @@
 ; vim: filetype=clojure
 
 (use '[clojure.string :only (join)])
-(use '[clojure.math.numeric-tower :only (abs)])
 (logging/init {:file "/var/log/riemann/riemann.log"})
 
 (def graph (graphite {:host "grafana_graphite" :port 2003}))


### PR DESCRIPTION
Add some real-world example metrics.

1. Counts the occurrences of the distinct event names, e.g. how many "main_iframe_ready" events were seen over the last 60 seconds. This is now aggregated using `moving-time-window`, but should probably be `fixed-time-window` in production to prevent graphite from being spammed constantly by updates.
2. Timestamp difference between `main_iframe_created` and `main_iframe_loaded` is calculated using the `project` aggregator which keeps the _last seen_ event that matches the predicate. Because it's grouped `by [:sid :iid]` there should technically only be 1 instance of each though.